### PR TITLE
Potential fix for code scanning alert no. 2: Double escaping or unescaping

### DIFF
--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -29,12 +29,12 @@ export async function sha256(text: string): Promise<string> {
  */
 export function decodeHtmlEntities(text: string): string {
   return text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&#x2F;/g, '/')
     .replace(/&#x60;/g, '`')
-    .replace(/&#x3D;/g, '=');
+    .replace(/&#x3D;/g, '=')
+    .replace(/&amp;/g, '&');
 }


### PR DESCRIPTION
Potential fix for [https://github.com/luthpg/linkbox/security/code-scanning/2](https://github.com/luthpg/linkbox/security/code-scanning/2)

To fix the issue, the replacements in the `decodeHtmlEntities` function should be reordered so that `&amp;` is decoded last. This ensures that ampersands are not prematurely unescaped, which could lead to incorrect decoding of other entities. The fix involves moving the `.replace(/&amp;/g, '&')` line to the end of the chain of replacements.

No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
